### PR TITLE
feat: mandatory description for OTHER incidents

### DIFF
--- a/frontend/src/components/incidents/IncidentForm.tsx
+++ b/frontend/src/components/incidents/IncidentForm.tsx
@@ -27,6 +27,13 @@ const IncidentForm: FC = () => {
             description: formData.get('description') as string || undefined,
         };
 
+        // Validación cliente específica para 'OTHER'
+        if (data.incidentType === IncidentType.OTHER && (!data.description || data.description.trim() === '')) {
+            const message = 'La descripción es obligatoria cuando seleccionas "Otro"';
+            setError(message);
+            return { success: false, error: message };
+        }
+
         try {
             await complaintsService.createComplaint(data);
             setIsModalOpen(true);

--- a/frontend/src/services/complaints.service.ts
+++ b/frontend/src/services/complaints.service.ts
@@ -15,7 +15,7 @@ export const complaintsService = {
 
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({}));
-                throw new Error(errorData.message || 'Error al enviar el reporte');
+                throw new Error(errorData.details || errorData.error || 'Error al enviar el reporte');
             }
 
             return await response.json();


### PR DESCRIPTION
Update incident form to make description field mandatory specifically when the 'OTHER' incident type is selected. Removed (Opcional) label in that case.